### PR TITLE
Correctly counting B45 assemblies

### DIFF
--- a/BOM Tools/frmBomTools.vb
+++ b/BOM Tools/frmBomTools.vb
@@ -37,7 +37,7 @@ Public Class frmBomTools
             mAssyDoc = g_inventorApplication.ActiveDocument
             'get the top level assembly document name
             startAssy = mAssyDoc.PropertySets.Item("Design Tracking Properties").Item("Part Number").Value
-            lblVersion.Text = "v1.9"
+            lblVersion.Text = "v1.10"
 
             'define colors for row highlighting
             colorPartNotOnList = Color.DeepPink


### PR DESCRIPTION
- bumped Bom Tools revision to 1.10
- Added code to handle incorrectly counting weldment assemblies.  Code checks the suboccurrence's documenSubType to see if it is a weldment.  Without this code, weldments would be counted twice.